### PR TITLE
Correct the "Katalon recorder" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Teaching material for a lecture (including practical exercises) on GUI testing.
 [Exercises](https://github.com/ssegura/GUITesting/raw/master/Exercises.pdf)    
 
 ## Required software 
-[Katalon recorder](https://www.google.com)  
+[Katalon recorder](https://www.katalon.com/katalon-recorder-ide/)  
 [Katalon studio (optional)](https://www.katalon.com/katalon-studio/)  
 [Java SDK](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)  
 [Eclipse IDE (optional)](https://www.eclipse.org/downloads/)  


### PR DESCRIPTION
The original link pointed to google.com instead of the site for the Katalon recorder.